### PR TITLE
feat(generation): support custom timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,18 +43,18 @@ Creates a new `UUIDv7` instance. By default it uses the [Base58](https://www.cs.
 #### `gen`
 
 ```typescript
-gen() => string
+gen(customTimestamp?: number) => string
 ```
 
-Generates a new UUIDv7.
+Generates a new UUIDv7. You can provide a custom timestamp to be used instead of the current one.
 
 #### `genMany`
 
 ```typescript
-genMany(amount: number) => string[]
+genMany(amount: number, customTimestamp?: number) => string[]
 ```
 
-Generates a custom amount of UUIDv7s.
+Generates a custom amount of UUIDv7s. You can provide a custom timestamp to be used instead of the current one.
 
 #### `encode`
 
@@ -128,6 +128,11 @@ This library implements the [RFC 9562](https://datatracker.ietf.org/doc/html/rfc
   - if both counters overflow their bit sizes, the generation function waits for the next millisecond to return a UUIDv7 with newly generated random parts.
 
 This approach follows the [method 2](https://datatracker.ietf.org/doc/html/rfc9562#monotonicity_counters) of the "Monotonicity and Counters" section of the spec. It guarantees monotonicity and uniqueness per instance, and always keeps timestamp the same as `Date.now()` value.
+
+If you provide a custom timestamp, it will be used instead of the current one. Generation works differently in this case:
+
+- if the custom timestamp is different from the last custom stored one, it generates new `rand_a` and `rand_b` parts;
+- if the custom timestamp is the same as the last custom stored one, it uses `rand_b` and then `rand_a` as randomly seeded counters, in that order, just like the normal generation method. If both `rand_a` and `rand_b` overflow, though, the generator throws an error informing that a valid UUIDv7 cannot be generated with the provided timestamp. This is an extremely rare case.
 
 ## Field and Bit Layout
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,7 +4,7 @@ import assert from "node:assert";
 import { test } from "node:test";
 import { UUIDv7, decodeOrThrowUUIDv7, decodeUUIDv7, encodeUUIDv7, uuidv7 } from ".";
 
-test("1_000_000 generated UUIDs should be valid and monotonic", () => {
+test("1_000_000 generated UUIDs with default timestamp should be valid and monotonic", () => {
 	const uuid = new UUIDv7();
 
 	uuid.genMany(1_000_000).forEach((id, idx, arr) => {
@@ -13,6 +13,16 @@ test("1_000_000 generated UUIDs should be valid and monotonic", () => {
 		if (idx > 0 && id <= arr[idx - 1]!) {
 			assert.fail(`UUIDs are not monotonic: ${id} <= ${arr[idx - 1]!}`);
 		}
+	});
+});
+
+test("1_000_000 generated UUIDs with custom timestamp should be valid and have the expected timestamp", () => {
+	const expectedTimestamp = 1716073376015;
+	const uuid = new UUIDv7();
+
+	uuid.genMany(1_000_000, expectedTimestamp).forEach((id) => {
+		assert.strictEqual(UUIDv7.isValid(id), true);
+		assert.strictEqual(UUIDv7.timestamp(id), expectedTimestamp);
 	});
 });
 


### PR DESCRIPTION
This PR adds the ability to provide a custom timestamp to generate UUIDv7(s).